### PR TITLE
isVisible CPU usage optimization

### DIFF
--- a/lib/in-view.js
+++ b/lib/in-view.js
@@ -35,6 +35,9 @@
 
 		// Return true if an element inside its parents and the viewport
 		function isVisible(element) {
+			if(element.style.position !== 'fixed' && element.offsetParent === null) {
+				return false;
+			}
 			return isInParents(element) && isInViewport(element);
 		}
 


### PR DESCRIPTION
When there are many ractive viewport elements on a page, the recursive nature of isInParents() leads to a lot of CPU usage even when these viewports are not being displayed.  This eliminates that usage when the element is not visible, which can be detected through the offsetParent property in modern browsers.  If this property is not available, isVisible() will continue to function as before.